### PR TITLE
fix: modify the order of storage plugin

### DIFF
--- a/src/pages/cluster/components/plugin/AddStorage.jsx
+++ b/src/pages/cluster/components/plugin/AddStorage.jsx
@@ -18,7 +18,16 @@ import React, { useEffect, useReducer, useRef } from 'react';
 import Tabs from 'components/Tabs';
 import styles from './index.less';
 import RenderForm from './RenderForm';
-import { cloneDeep, uniq, omit, set, assign, isArray, isMatch } from 'lodash';
+import {
+  cloneDeep,
+  uniq,
+  omit,
+  set,
+  assign,
+  isArray,
+  isMatch,
+  orderBy,
+} from 'lodash';
 import { useParams, useHistory } from 'react-router-dom';
 import { encodeProperty } from 'utils';
 import Notify from 'components/Notify';
@@ -62,7 +71,7 @@ const Storage = observer((props) => {
         .map((item) => item?.name)
         .filter((item) => !!item);
 
-      const newTabs = cloneDeep(storageComponents).map((item) => {
+      let newTabs = cloneDeep(storageComponents).map((item) => {
         const { properties = {} } = item.schema;
 
         delete properties.isDefaultSC;
@@ -110,6 +119,8 @@ const Storage = observer((props) => {
           formInstances: [],
         };
       });
+
+      newTabs = orderBy(newTabs, ['deprecated'], 'asc');
 
       setState({
         ...state,

--- a/src/pages/cluster/components/plugin/StorageForm.jsx
+++ b/src/pages/cluster/components/plugin/StorageForm.jsx
@@ -17,7 +17,7 @@
 import React, { useEffect } from 'react';
 import { observer } from 'mobx-react';
 import Tabs from 'components/Tabs';
-import { cloneDeep, uniq, set, isMatch, isEmpty } from 'lodash';
+import { cloneDeep, uniq, set, isMatch, isEmpty, orderBy } from 'lodash';
 import RenderForm from './RenderForm';
 import { Divider, Button } from 'antd';
 import { Context } from './Context';
@@ -55,7 +55,7 @@ const StorageForm = (props) => {
   useEffect(() => {
     if (!isEmpty(storageTabs)) return;
 
-    const newTabs = cloneDeep(storageComponents).map((item) => {
+    let newTabs = cloneDeep(storageComponents).map((item) => {
       const { name } = item;
       const { properties = {} } = item.schema;
 
@@ -114,9 +114,10 @@ const StorageForm = (props) => {
         formInstances: [],
       };
     });
+    newTabs = orderBy(newTabs, ['deprecated'], 'asc');
 
     updateContext({
-      storageCurrent: storageComponents[0]?.name,
+      storageCurrent: newTabs[0]?.name,
       storageTabs: newTabs,
     });
   }, [storageComponents]);


### PR DESCRIPTION
Signed-off-by: liuying <liu.ying@99cloud.net>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #206 

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```