### PR TITLE
refactor: refactor ipgroup component

### DIFF
--- a/src/components/FormItem/IPGroup/index.jsx
+++ b/src/components/FormItem/IPGroup/index.jsx
@@ -13,38 +13,24 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import React, { useState } from 'react';
+import React from 'react';
 import { Input, Select } from 'antd';
+import { useMergedState } from 'hooks';
 import PropTypes from 'prop-types';
 
 const { Option } = Select;
 
 export default function IPGroup(props) {
-  const { onChange, value, className } = props;
+  const { value, className } = props;
+  const [prefix, setPrefix] = useMergedState('http', {
+    value: value?.prefix,
+    onChange: props.onChange,
+  });
 
-  const [prefix, setPrefix] = useState('http');
-  const [ip, setIp] = useState('');
-
-  if (prefix !== value?.prefix) {
-    setPrefix(value?.prefix);
-  }
-  if (ip !== value?.ip) {
-    setIp(value?.ip);
-  }
-
-  const onPrefixChange = (_prefix) => {
-    onChange?.({
-      prefix: _prefix,
-      ip,
-    });
-  };
-
-  const onIPChange = (e) => {
-    onChange?.({
-      prefix,
-      ip: e.target.value,
-    });
-  };
+  const [ip, setIp] = useMergedState('', {
+    value: value?.ip,
+    onChange: props.onChange,
+  });
 
   return (
     <Input.Group compact className={className}>
@@ -53,7 +39,7 @@ export default function IPGroup(props) {
           width: '30%',
         }}
         value={prefix}
-        onChange={onPrefixChange}
+        onChange={(_prefix) => setPrefix({ prefix: _prefix, ip })}
       >
         <Option value="http">http</Option>
         <Option value="https">https</Option>
@@ -63,7 +49,7 @@ export default function IPGroup(props) {
           width: '70%',
         }}
         value={ip}
-        onChange={onIPChange}
+        onChange={(e) => setIp({ prefix, ip: e.target.value })}
       />
     </Input.Group>
   );


### PR DESCRIPTION
Signed-off-by: moweiwei <mo.weiwei@99cloud.net>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```