### PR TITLE
fix: use plugin template error & operaiton list cached by cluster detail

### DIFF
--- a/src/pages/cluster/components/plugin/AddPlugin.jsx
+++ b/src/pages/cluster/components/plugin/AddPlugin.jsx
@@ -111,35 +111,24 @@ const Plugin = (props) => {
   };
 
   const handleFRChange = (name, formInstance, formData, index) => {
-    if (typeof formData === 'object' && formData.pluginTemplate) {
+    if (formData.pluginTemplate) {
       if (formData.pluginTemplate !== 'notUseTemplate') {
-        const { flatData = {} } = templates.find(
-          (item) => item.id === formData.pluginTemplate
+        const selectedTemplate = templates.find(
+          (item) => item.name === formData.pluginTemplate
         );
-        if (!isMatch(formData, flatData)) {
+
+        if (!isMatch(formData, selectedTemplate.flatData)) {
           formInstance.setValues({
-            ...formData,
-            pluginTemplate: '',
+            ...selectedTemplate.flatData,
+            pluginTemplate: formData.pluginTemplate,
+            enable: true,
           });
         }
-      }
-    }
-
-    if (typeof formData === 'string') {
-      if (formData === 'notUseTemplate') {
+      } else {
         const { baseFormData } = tabs.find((item) => item.name === current);
         formInstance.setValues({
           ...baseFormData,
           pluginTemplate: 'notUseTemplate',
-          enable: true,
-        });
-      } else {
-        const [{ flatData = {} }] = templates.filter(
-          (item) => item.name === formData
-        );
-        formInstance.setValues({
-          ...flatData,
-          pluginTemplate: formData,
           enable: true,
         });
       }

--- a/src/pages/cluster/components/plugin/PluginForm.jsx
+++ b/src/pages/cluster/components/plugin/PluginForm.jsx
@@ -115,35 +115,23 @@ const PluginForm = (props) => {
   };
 
   const handleFRChange = (name, formInstance, formData) => {
-    if (typeof formData === 'object' && formData.pluginTemplate) {
+    if (formData.pluginTemplate) {
       if (formData.pluginTemplate !== 'notUseTemplate') {
-        const { flatData = {} } = templates.find(
-          (item) => item.id === formData.pluginTemplate
+        const selectedTemplate = templates.find(
+          (item) => item.name === formData.pluginTemplate
         );
-        if (!isMatch(formData, flatData)) {
+        if (!isMatch(formData, selectedTemplate.flatData)) {
           formInstance.setValues({
-            ...formData,
-            pluginTemplate: '',
+            ...selectedTemplate.flatData,
+            pluginTemplate: formData.pluginTemplate,
+            enable: true,
           });
         }
-      }
-    }
-
-    if (typeof formData === 'string') {
-      if (formData === 'notUseTemplate') {
+      } else {
         const { baseFormData } = tabs.find((item) => item.name === current);
         formInstance.setValues({
           ...baseFormData,
           pluginTemplate: 'notUseTemplate',
-          enable: true,
-        });
-      } else {
-        const [{ flatData = {} }] = templates.filter(
-          (item) => item.name === formData
-        );
-        formInstance.setValues({
-          ...flatData,
-          pluginTemplate: formData,
           enable: true,
         });
       }

--- a/src/pages/cluster/containers/Cluster/Detail/Operation/index.jsx
+++ b/src/pages/cluster/containers/Cluster/Detail/Operation/index.jsx
@@ -13,10 +13,11 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import React from 'react';
+import React, { useMemo } from 'react';
 import BaseList from 'containers/List';
 import { operationStatus } from 'resources/cluster';
 import { useRootStore } from 'stores';
+import { observer } from 'mobx-react';
 import actionConfigs from './actions';
 import { useParams } from 'react-router-dom';
 
@@ -71,7 +72,7 @@ function OperationList() {
     await store.fetchList({ labelSelector, ...params });
   }
 
-  return <BaseList {...currentProps} />;
+  return useMemo(() => <BaseList {...currentProps} />, [store.detail]);
 }
 
-export default OperationList;
+export default observer(OperationList);


### PR DESCRIPTION
Signed-off-by: liuying <liu.ying@99cloud.net>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

### What this PR does / why we need it:

### Which issue(s) this PR fixes:

<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Fixes #

### Special notes for reviewers:

```

```

### Does this PR introduced a user-facing change?

<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->

```release-note

```

### Additional documentation, usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```
