### PR TITLE
fix: plugin cannot be removed when cluster is no running

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -597,5 +597,6 @@
   "Delete the registry will invalidate the configured cluster CRI registry. Please ensure that registry is no longer used before deleting.": "Delete the registry will invalidate the configured cluster CRI registry. Please ensure that registry is no longer used before deleting.",
   "Update CRI Registry": "Update CRI Registry",
   "Cluster {name} {action} successfully.": "Cluster {name} {action} successfully.",
-  "Master Node Healthy Status": "Master Node Healthy Status"
+  "Master Node Healthy Status": "Master Node Healthy Status",
+  "Container Registry": "Container Registry"
 }

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -597,5 +597,6 @@
   "Delete the registry will invalidate the configured cluster CRI registry. Please ensure that registry is no longer used before deleting.": "删除镜像仓库会导致已配置的集群 CRI 镜像仓库失效，请确保此镜像仓库不再使用再删除。",
   "Update CRI Registry": "更新 CRI 镜像仓库",
   "Cluster {name} {action} successfully.": "集群 {name} {action}成功",
-  "Master Node Healthy Status": "控制节点健康状态"
+  "Master Node Healthy Status": "控制节点健康状态",
+  "Container Registry": "容器镜像仓库"
 }

--- a/src/pages/cluster/containers/Cluster/Detail/Plugins/index.jsx
+++ b/src/pages/cluster/containers/Cluster/Detail/Plugins/index.jsx
@@ -24,6 +24,7 @@ import SaveAsTemplate from '../../actions/SaveAsTemplate';
 import { getAction } from 'utils/allowed';
 import { toJS } from 'mobx';
 import { useParams } from 'react-router';
+import { checkExpired, isDisableByProviderType } from 'utils';
 
 function Plugins() {
   const { clusterStore: store, components } = useRootStore();
@@ -186,9 +187,19 @@ function Plugins() {
           },
         };
 
+        const isLicensExpiration = () =>
+          checkExpired(store.detail.licenseExpirationTime);
+
+        const isStatusRunning = () => store.detail.status === 'Running';
+
+        const allowed = () =>
+          isLicensExpiration() &&
+          isStatusRunning() &&
+          !isDisableByProviderType(store.detail);
+
         const deleteButtonProps = {
           id: item.name,
-          isAllowed: true,
+          isAllowed: allowed(),
           title: t('Remove'),
           buttonType: 'link',
           actionType: 'confirm',

--- a/src/pages/cluster/containers/Cluster/Detail/Storage/index.jsx
+++ b/src/pages/cluster/containers/Cluster/Detail/Storage/index.jsx
@@ -23,6 +23,7 @@ import SaveAsTemplate from '../../actions/SaveAsTemplate';
 import { getAction } from 'utils/allowed';
 import { toJS } from 'mobx';
 import { useParams } from 'react-router';
+import { checkExpired, isDisableByProviderType } from 'utils';
 
 export default function Storage() {
   const { clusterStore: store, components } = useRootStore();
@@ -77,9 +78,19 @@ export default function Storage() {
           },
         };
 
+        const isLicensExpiration = () =>
+          checkExpired(store.detail.licenseExpirationTime);
+
+        const isStatusRunning = () => store.detail.status === 'Running';
+
+        const allowed = () =>
+          isLicensExpiration() &&
+          isStatusRunning() &&
+          !isDisableByProviderType(store.detail);
+
         const deleteButtonProps = {
           id: `${item.name}-${index}`,
-          isAllowed: true,
+          isAllowed: allowed(),
           title: t('Remove'),
           buttonType: 'link',
           actionType: 'confirm',


### PR DESCRIPTION
Signed-off-by: liuying <liu.ying@99cloud.net>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

### What this PR does / why we need it:

### Which issue(s) this PR fixes:

<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Fixes #250

### Special notes for reviewers:

```

```

### Does this PR introduced a user-facing change?

<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->

```release-note

```

### Additional documentation, usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```
