### PR TITLE
fix: rancher healthy not displayed

### DIFF
--- a/src/pages/cluster/containers/Cluster/Detail/BaseDetail/index.jsx
+++ b/src/pages/cluster/containers/Cluster/Detail/BaseDetail/index.jsx
@@ -18,6 +18,7 @@ import Base from 'containers/BaseDetail';
 import { get, uniq } from 'lodash';
 import { useRootStore } from 'stores';
 import { observer } from 'mobx-react';
+import { isDisableByProviderType } from 'utils';
 
 function BaseDetail() {
   const { clusterStore: store } = useRootStore();
@@ -116,17 +117,20 @@ function BaseDetail() {
         dataIndex: 'externalIP',
       },
       {
-        label: t('Master Node Healthy Status'),
+        label: t('Master'),
         dataIndex: 'controlPlaneHealth',
-        render: (data) => (
-          <>
-            {data.map(({ hostname, address, status }, index) => (
-              <p key={index}>
-                {hostname} | {address} ｜ {t(status)}
-              </p>
-            ))}
-          </>
-        ),
+        render: (data) => {
+          const isRancher = isDisableByProviderType(store.detail);
+          return (
+            <>
+              {data.map(({ hostname, address, status }, index) => (
+                <p key={index}>
+                  {hostname} | {address} {!isRancher ? `｜ ${t(status)}` : ''}
+                </p>
+              ))}
+            </>
+          );
+        },
       },
       {
         label: t('Cluster Labels'),


### PR DESCRIPTION
Signed-off-by: liuying <liu.ying@99cloud.net>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

### What this PR does / why we need it:

### Which issue(s) this PR fixes:

<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Fixes #

### Special notes for reviewers:

```

```

### Does this PR introduced a user-facing change?

<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->

```release-note

```

### Additional documentation, usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```
