### PR TITLE
fix: calico saved failed in cluster template

### DIFF
--- a/src/pages/cluster/containers/Template/cluster/actions/Create/Cluster.jsx
+++ b/src/pages/cluster/containers/Template/cluster/actions/Create/Cluster.jsx
@@ -261,8 +261,8 @@ export default class Cluster extends BaseForm {
   }
 
   get isDocker() {
-    const type = this.state.containerRuntimeType;
-    return type === 'docker';
+    const { containerRuntimeType } = this.props.context;
+    return containerRuntimeType === 'docker';
   }
 
   get nameForStateUpdate() {
@@ -277,19 +277,19 @@ export default class Cluster extends BaseForm {
   }
 
   get isCalico() {
-    const { cniType } = this.state;
+    const { cniType } = this.props.context;
 
     return cniType === 'calico';
   }
 
   get isDualStack() {
-    const { IPVersion } = this.state;
+    const { IPVersion } = this.props.context;
 
     return IPVersion === 'IPv4+IPv6';
   }
 
   checkIpOrDomain = (rule, value) => {
-    const { pod_network_underlay } = this.state;
+    const { pod_network_underlay } = this.props.context;
     if (pod_network_underlay === 'can-reach') {
       if (isIPv4(value) || isDomain(value)) {
         return Promise.resolve(true);
@@ -306,7 +306,7 @@ export default class Cluster extends BaseForm {
   };
 
   checkIpOrDomainV6 = (rule, value) => {
-    const { pod_network_underlay } = this.state;
+    const { pod_network_underlay } = this.props.context;
     if (pod_network_underlay === 'can-reach') {
       if (isIpv6(value) || isDomain(value)) {
         return Promise.resolve(true);
@@ -476,7 +476,8 @@ export default class Cluster extends BaseForm {
   };
 
   get formItems() {
-    const { pod_network_underlay, pod_network_underlay_v6 } = this.state;
+    const { pod_network_underlay, pod_network_underlay_v6 } =
+      this.props.context;
     const { isAfter24 = false } = this.props.context;
 
     const underlayInputHelp =


### PR DESCRIPTION
Signed-off-by: liuying <liu.ying@99cloud.net>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

### What this PR does / why we need it:

### Which issue(s) this PR fixes:

<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Fixes #

### Special notes for reviewers:

```

```

### Does this PR introduced a user-facing change?

<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->

```release-note

```

### Additional documentation, usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```
