### PR TITLE
fix: the storageclass form used by select or input

### DIFF
--- a/src/components/FormRender/index.jsx
+++ b/src/components/FormRender/index.jsx
@@ -26,6 +26,7 @@ import ArrayString from './widgets/ArrayString';
 import ArrayText from './widgets/ArrayText';
 import KSPlugins from './widgets/KSPlugins';
 import MyCheckBox from './widgets/MyCheckBox';
+import SelectInput from './widgets/SelectInput';
 
 /**
  * 自定义组件（widget）
@@ -41,6 +42,7 @@ const widgets = {
   // mapping
   CustomBoolean,
   collapse: Collapses,
+  'select-input': SelectInput,
 };
 
 /**

--- a/src/components/FormRender/widgets/SelectInput/index.jsx
+++ b/src/components/FormRender/widgets/SelectInput/index.jsx
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021 KubeClipper Authors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import React from 'react';
+import { Select } from 'antd';
+import SelectWithInput from 'components/FormItem/SelectWithInput';
+
+const SelectInput = (props) => {
+  const { schema, ...rest } = props;
+
+  const formatValue = (schema.enum || []).map((item, index) => ({
+    value: item,
+    index,
+  }));
+  return <SelectWithInput options={formatValue} {...rest} />;
+};
+Select;
+
+export default SelectInput;

--- a/src/pages/cluster/components/plugin/uiSchemas.js
+++ b/src/pages/cluster/components/plugin/uiSchemas.js
@@ -35,7 +35,7 @@ export const uiSchemas = [
           widget: 'KSPlugins',
         },
         storageClass: {
-          widget: 'select',
+          widget: 'select-input',
         },
         HostClusterName: {
           hidden:


### PR DESCRIPTION
Signed-off-by: liuying <liu.ying@99cloud.net>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

### What this PR does / why we need it:

### Which issue(s) this PR fixes:

<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Fixes #

### Special notes for reviewers:

```

```

### Does this PR introduced a user-facing change?

<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->

```release-note

```

### Additional documentation, usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```
