### PR TITLE
feat: add external domain&domainPort for create cluster

### DIFF
--- a/src/components/FormItem/index.jsx
+++ b/src/components/FormItem/index.jsx
@@ -32,6 +32,7 @@ import SelectTable from './SelectTable';
 import More from './More';
 import ArrayInput from './ArrayInput';
 import IpInput from './IpInput';
+import IpPort from './IpPort';
 import Radio from './Radio';
 import Descriptions from './Descriptions';
 import NameInput from './NameInput';
@@ -91,6 +92,7 @@ export const type2component = {
   'dns-record': DNSRecord,
   'yaml-input': YamlInput,
   'ip-group': IPGroup,
+  'ip-port': IpPort,
 };
 
 export default function FormItem(props) {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -601,5 +601,7 @@
   "Host Cluster Name": "Host Cluster Name",
   "Cluster {clusters} is using this backup space. Deleting the backup space will automatically unbind the relationship. Are you sure you want to delete this backup space?": "Cluster {clusters} is using this backup space. Deleting the backup space will automatically unbind the relationship. Are you sure you want to delete this backup space?",
   "Cluster Node Name": "Cluster Node Name",
-  "If IP is selected, this IP string will be used as the node ID instead of the actual host name.": "If IP is selected, this IP string will be used as the node ID instead of the actual host name."
+  "If IP is selected, this IP string will be used as the node ID instead of the actual host name.": "If IP is selected, this IP string will be used as the node ID instead of the actual host name.",
+  "Please enter a legal domain": "Please enter a legal domain",
+  "External Access Domain": "External Access Domain"
 }

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -601,5 +601,7 @@
   "Host Cluster Name": "主机集群名称",
   "Cluster {clusters} is using this backup space. Deleting the backup space will automatically unbind the relationship. Are you sure you want to delete this backup space?": "集群 {clusters} 正在使用此备份空间，删除备份空间将自动解除绑定关系，确认删除此备份空间？",
   "Cluster Node Name": "集群节点名称",
-  "If IP is selected, this IP string will be used as the node ID instead of the actual host name.": "如果选择了 IP，将使用此 IP 字符串作为节点标识，而不是实际的主机名。"
+  "If IP is selected, this IP string will be used as the node ID instead of the actual host name.": "如果选择了 IP，将使用此 IP 字符串作为节点标识，而不是实际的主机名。",
+  "Please enter a legal domain": "请输入合法的域名",
+  "External Access Domain": "外部访问域名"
 }

--- a/src/pages/cluster/containers/Cluster/actions/Create/Cluster.jsx
+++ b/src/pages/cluster/containers/Cluster/actions/Create/Cluster.jsx
@@ -24,6 +24,8 @@ import {
   isDomain,
   isDomainPath,
   isIpPort,
+  isDomainPort,
+  isIp,
 } from 'utils/validate';
 import {
   clusterParams,
@@ -469,7 +471,8 @@ export default class Cluster extends BaseForm {
   };
 
   checkIP = async (_, value) => {
-    if (value && !isIPv4(value)) {
+    const { ip } = value;
+    if (ip && !isIp(ip)) {
       return Promise.reject(t('IP invalid'));
     }
     return Promise.resolve();
@@ -875,9 +878,23 @@ export default class Cluster extends BaseForm {
         {
           name: 'externalIP',
           label: t('External Access IP'),
-          type: 'ip-input',
+          type: 'ip-port',
           tip: t('Set up a floating IP for end users to access.'),
           validator: this.checkIP,
+        },
+        {
+          name: 'externalDomain',
+          label: t('External Access Domain'),
+          type: 'input',
+          validator: (rule, value) => {
+            if (!value) return Promise.resolve(true);
+
+            if (isDomainPort(value)) {
+              return Promise.resolve(true);
+            } else {
+              return Promise.reject(t('Please enter a legal domain'));
+            }
+          },
         },
         {
           name: 'backupPoint',

--- a/src/pages/cluster/containers/Cluster/actions/Create/Confirm.jsx
+++ b/src/pages/cluster/containers/Cluster/actions/Create/Confirm.jsx
@@ -235,7 +235,7 @@ export class ConfirmStep extends BaseForm {
 
     return [
       ...this.notFilled(t('Description'), 'description'),
-      ...this.notFilled(t('External Access IP'), 'externalIP'),
+      ...this.notFilled(t('External Access IP'), 'externalIP.ip'),
       {
         label: t('Image Type'),
         value: offline ? t('Offline') : t('Online'),

--- a/src/pages/cluster/containers/Cluster/actions/Create/index.jsx
+++ b/src/pages/cluster/containers/Cluster/actions/Create/index.jsx
@@ -209,6 +209,7 @@ export default class Create extends StepAction {
       name,
       description,
       externalIP,
+      externalDomain,
       labels,
     } = values;
 
@@ -228,8 +229,21 @@ export default class Create extends StepAction {
     const { IPv4AutoDetection, IPv6AutoDetection } =
       computeAutoDetection(values);
 
-    const externalIPLabel = externalIP
-      ? { 'kubeclipper.io/externalIP': externalIP }
+    const externalIPLabel = externalIP.ip
+      ? { 'kubeclipper.io/externalIP': externalIP.ip }
+      : {};
+
+    const externalPortLabel = externalIP.port
+      ? { 'kubeclipper.io/externalPort': String(externalIP.port) }
+      : {};
+
+    const [domain, domainPort] = externalDomain.split(':');
+    const externalDomainlabel = domain
+      ? { 'kubeclipper.io/externalDomain': domain }
+      : {};
+
+    const externalDomainPortlabel = domainPort
+      ? { 'kubeclipper.io/externalDomainPort': domainPort }
       : {};
 
     const offlineAnnotations = offline ? { 'kubeclipper.io/offline': '' } : {};
@@ -243,6 +257,9 @@ export default class Create extends StepAction {
           'topology.kubeclipper.io/region': region,
           'kubeclipper.io/backupPoint': backupPoint,
           ...externalIPLabel,
+          ...externalPortLabel,
+          ...externalDomainlabel,
+          ...externalDomainPortlabel,
           ...arrayInput2Label(labels),
         },
         annotations: {

--- a/src/pages/cluster/containers/Template/cluster/actions/Create/Cluster.jsx
+++ b/src/pages/cluster/containers/Template/cluster/actions/Create/Cluster.jsx
@@ -860,8 +860,13 @@ export default class Cluster extends BaseForm {
         {
           name: 'externalIP',
           label: t('External Access IP'),
-          type: 'ip-input',
+          type: 'ip-port',
           tip: t('Set up a floating IP for end users to access.'),
+        },
+        {
+          name: 'externalDomain',
+          label: t('External Access Domain'),
+          type: 'input',
         },
         {
           name: 'backupPoint',

--- a/src/pages/cluster/containers/Template/cluster/actions/Create/Confirm.jsx
+++ b/src/pages/cluster/containers/Template/cluster/actions/Create/Confirm.jsx
@@ -220,7 +220,7 @@ export class ConfirmStep extends BaseForm {
     } = context;
     return [
       ...this.notFilled(t('Description'), 'description'),
-      ...this.notFilled(t('External Access IP'), 'externalIP'),
+      ...this.notFilled(t('External Access IP'), 'externalIP.ip'),
       {
         label: t('Image Type'),
         value: offline ? t('Offline') : t('Online'),

--- a/src/utils/validate.js
+++ b/src/utils/validate.js
@@ -39,7 +39,8 @@ const domain =
 const domainPath =
   // eslint-disable-next-line no-useless-escape
   /[\w\-]+(\.[\w\-]+)+([\w\-\.,@?^=%&:\/~\+#]*[\w\-\@?^=%&\/~\+#])?$/;
-
+const domainPort =
+  /^((http|https):\/\/)?([a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,}(:[0-9]{1,5})?$/i;
 const emailRegex =
   /^[A-Za-z\d]+([-_.][A-Za-z\d]+)*@([A-Za-z\d]+[-.])+[A-Za-z\d]{2,4}$/;
 const phoneNumberRegex = /^1[3456789]\d{9}$/;
@@ -61,6 +62,7 @@ export const regex = {
   portRangeRegex,
   ipWithMask,
   emailRegex,
+  domainPort,
 };
 
 export const isPhoneNumber = (value) => phoneNumberRegex.test(value);
@@ -96,6 +98,8 @@ export const isIpv6 = (value) => value && Address6.isValid(value);
 export const isDomain = (value) => domain.test(value);
 
 export const isDomainPath = (value) => domainPath.test(value);
+
+export const isDomainPort = (value) => domainPort.test(value);
 
 export const isCidr = (value) => cidr.test(value);
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

### What this PR does / why we need it:

### Which issue(s) this PR fixes:

<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Fixes #

### Special notes for reviewers:

```

```

### Does this PR introduced a user-facing change?

<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->

```release-note

```

### Additional documentation, usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```
