### PR TITLE
ci: remove oss upload from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,22 +61,10 @@ jobs:
           ls -F | xargs tar -zcvf kc-console.tar.gz
           popd
 
-      - name: Setup ossutil
-        uses: manyuanrong/setup-ossutil@v2.0
-        with:
-          endpoint:  ${{ secrets.OSS_ENDPOINT }}
-          access-key-id: ${{ secrets.OSS_ACCESS_KEY }}
-          access-key-secret: ${{ secrets.OSS_ACCESS_SECRET }}
-      - name: Upload to oss
-        run: |
-          ossutil cp -rf dist/kc-console.tar.gz oss://${{ secrets.OSS_BUCKET }}/kc-console/${{ steps.extract_branch.outputs.branch }}/
-
       - name: Release
         uses: softprops/action-gh-release@v1
         if: startsWith(steps.extract_branch.outputs.branch, 'v')
         with:
           files: |
             dist/kc-console.tar.gz
-          # note you'll typically need to create a personal access token
-          # with permissions to create releases in the other repo
           token: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
## Summary

- `release.yml` 和 `buid.yaml` 职责分离
- `buid.yaml`（push master/release* 触发）：build + upload OSS
- `release.yml`（v* tag 触发）：build + create GitHub Release
- 去掉 release.yml 中重复的 OSS 上传步骤，避免 tag push 时两个 workflow 都做 build + upload

Cherry-pick from #426