### PR TITLE
fix: keep navigation on single-character cluster details

### DIFF
--- a/src/core/menu.js
+++ b/src/core/menu.js
@@ -47,7 +47,7 @@ const renderMenu = (t) => {
               module: 'clusters',
             },
             {
-              path: /^\/cluster\/.[^/]+$/,
+              path: /^\/cluster\/[^/]+$/,
               name: t('Cluster Detail'),
               key: 'cluster-detail',
               level: 2,

--- a/src/layouts/Base/Left/menus.jsx
+++ b/src/layouts/Base/Left/menus.jsx
@@ -201,8 +201,6 @@ function Menus() {
     .map((item) => renderMenuItem(item))
     .filter((it) => it !== null);
 
-  if (!openKeys.length && !currentRoutes.length) return;
-
   return (
     <Menu
       theme="dark"


### PR DESCRIPTION
/kind bug
/kind regression

### What this PR does / why we need it:

Fixes the cluster-detail menu route matcher so single-character cluster IDs keep the left navigation visible.

### Which issue(s) this PR fixes:

Fixes #

### Special notes for reviewers:

The previous pattern required at least two characters after `/cluster/`, so `/cluster/c` did not match and the menu rendered nothing.

### Does this PR introduced a user-facing change?

```release-note
Fix missing left navigation on cluster detail pages whose cluster ID has one character.
```

### Additional documentation, usage docs, etc.:

```docs

```