### PR TITLE
ci: skip expired OSS certificate verification

### DIFF
--- a/.github/workflows/buid.yaml
+++ b/.github/workflows/buid.yaml
@@ -59,7 +59,7 @@ jobs:
       - name: Compress
         run: |
           pushd dist
-          curl -O https://oss.kubeclipper.io/kube-console/master/kube-console.tar.gz
+          curl -kO https://oss.kubeclipper.io/kube-console/master/kube-console.tar.gz
           mkdir kube
           tar -C kube/ -xvzf kube-console.tar.gz
           rm -rf kube-console.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Compress
         run: |
           pushd dist
-          curl -O https://oss.kubeclipper.io/kube-console/master/kube-console.tar.gz
+          curl -kO https://oss.kubeclipper.io/kube-console/master/kube-console.tar.gz
           mkdir kube
           tar -C kube/ -xvzf kube-console.tar.gz
           rm -rf kube-console.tar.gz


### PR DESCRIPTION
## Summary
- pass `-k` to the OSS download in the build workflow
- apply the same workaround to the release workflow
- restore CI downloads while the `oss.kubeclipper.io` certificate is expired

## Verification
- confirmed the download returns HTTP 200 when certificate verification is skipped
- `git diff --check` passed

This is a temporary workaround. The OSS certificate should still be renewed and `-k` removed afterward.